### PR TITLE
Add storing offset scroll for click

### DIFF
--- a/mixins/textbox.go
+++ b/mixins/textbox.go
@@ -41,6 +41,7 @@ type TextBox struct {
 	selectionDragging bool
 	selectionDrag     gxui.TextSelection
 	desiredWidth      int
+	startOffset       int
 
 	horizScroll      gxui.ScrollBar
 	horizScrollChild *gxui.Child
@@ -49,6 +50,7 @@ type TextBox struct {
 
 func (t *TextBox) lineMouseDown(line TextBoxLine, ev gxui.MouseEvent) {
 	if ev.Button == gxui.MouseButtonLeft {
+		t.startOffset = t.List.ScrollOffset()
 		p := line.RuneIndexAt(ev.Point)
 		t.selectionDragging = true
 		t.selectionDrag = gxui.CreateTextSelection(p, p, false)
@@ -60,6 +62,7 @@ func (t *TextBox) lineMouseDown(line TextBoxLine, ev gxui.MouseEvent) {
 
 func (t *TextBox) lineMouseUp(line TextBoxLine, ev gxui.MouseEvent) {
 	if ev.Button == gxui.MouseButtonLeft {
+		t.startOffset = math.Min(t.startOffset, t.List.ScrollOffset())
 		t.selectionDragging = false
 		if !ev.Modifier.Control() {
 			t.controller.SetSelection(t.selectionDrag)
@@ -277,6 +280,10 @@ func (t *TextBox) SetDesiredWidth(desiredWidth int) {
 		t.desiredWidth = desiredWidth
 		t.SizeChanged()
 	}
+}
+
+func (t *TextBox) StartOffset() int {
+	return t.startOffset
 }
 
 func (t *TextBox) Select(sel gxui.TextSelectionList) {

--- a/textbox.go
+++ b/textbox.go
@@ -24,6 +24,7 @@ type TextBox interface {
 	SetMultiline(bool)
 	DesiredWidth() int
 	SetDesiredWidth(desiredWidth int)
+	StartOffset() int
 	TextColor() Color
 	SetTextColor(Color)
 	Select(TextSelectionList)


### PR DESCRIPTION
That's for https://github.com/nelsam/vidar/issues/100 , with it caret of editor can easily move to old scroll positions if change [input handler](https://github.com/nelsam/vidar/blob/master/command/input/handler.go#L187) for [that](https://gist.github.com/Kvaz1r/d55c0a9bc6348ed0c5a28ef1a91589de). 