### PR TITLE
check for PaintSelections

### DIFF
--- a/mixins/default_textbox_line.go
+++ b/mixins/default_textbox_line.go
@@ -149,10 +149,13 @@ func (t *DefaultTextBoxLine) PaintSelections(c gxui.Canvas) {
 	for _, s := range selections {
 		start := s.Start()
 		end := s.End()
+		if start == end {
+			continue
+		}
 		if start > end {
 			start, end = end, start
 		}
-		if end <= ls {
+		if end <= ls || start >= le {
 			continue
 		}
 		if start <= ls && end > le {


### PR DESCRIPTION
Add check for DefaultTextBoxLine like it already was doing for [CodeEditorLine](https://github.com/nelsam/gxui/blob/master/mixins/code_editor_line.go#L173). 
Without it gxui provide some excess incorrect selections for multiline textbox in random place. I couldn't find the reason of it, but guess that check will not redundant in any case.   