### PR TITLE
Add overrides for CodeEditor

### DIFF
--- a/mixins/default_textbox_line.go
+++ b/mixins/default_textbox_line.go
@@ -201,6 +201,6 @@ func (t *DefaultTextBoxLine) PositionAt(runeIndex int) math.Point {
 	controller := t.textbox.controller
 
 	x := runeIndex - controller.LineStart(t.lineIndex)
-	line := controller.Line(t.lineIndex)
-	return font.Measure(&gxui.TextBlock{Runes: []rune(line)[:x]}).Point()
+	runes := controller.LineRunes(t.lineIndex)
+	return font.Measure(&gxui.TextBlock{Runes: runes[:x]}).Point()
 }

--- a/mixins/textbox.go
+++ b/mixins/textbox.go
@@ -54,6 +54,7 @@ type TextBox struct {
 	horizScroll      gxui.ScrollBar
 	horizScrollChild *gxui.Child
 	horizOffset      int
+	horizScrollES    gxui.EventSubscription
 }
 
 func (t *TextBox) lineMouseDown(line TextBoxLine, ev gxui.MouseEvent) {
@@ -96,7 +97,7 @@ func (t *TextBox) Init(outer TextBoxOuter, driver gxui.Driver, theme gxui.Theme,
 	t.horizScroll = theme.CreateScrollBar()
 	t.horizScrollChild = t.AddChild(t.horizScroll)
 	t.horizScroll.SetOrientation(gxui.Horizontal)
-	t.horizScroll.OnScroll(func(from, to int) {
+	t.horizScrollES = t.horizScroll.OnScroll(func(from, to int) {
 		t.SetHorizOffset(from)
 	})
 


### PR DESCRIPTION
Fix for https://github.com/nelsam/vidar/issues/137

The reason - incorrect estimation of [MaxLineWidth](https://github.com/Kvaz1r/gxui/blob/hscroll_updates/mixins/textbox.go#L118), which get TextBox since Code Editor uses its own method for defining [PositionAt](https://github.com/Kvaz1r/gxui/blob/hscroll_updates/mixins/code_editor_line.go#L246).

Unlisten [here](https://github.com/Kvaz1r/gxui/blob/hscroll_updates/mixins/code_editor.go#L49) for preventing possible conflict between old call OnScroll and new one. 

Another approach - unite PositionAt methods, but I'm not sure that in this case anything else will not broken. 