### PR TITLE
Improvements for panel holder

### DIFF
--- a/mixins/panel_holder.go
+++ b/mixins/panel_holder.go
@@ -51,6 +51,8 @@ type PanelHolder struct {
 
 	begin int
 	end   int
+
+	switchMode gxui.SwitchMode
 }
 
 func insertIndex(holder gxui.PanelHolder, at math.Point) int {
@@ -246,6 +248,9 @@ func (p *PanelHolder) SelectNext() {
 	if N != 0 {
 		ind = ind + 1
 		if ind == N {
+			if p.switchMode == gxui.Linear {
+				return
+			}
 			ind = 0
 		}
 		p.Select(ind)
@@ -258,6 +263,9 @@ func (p *PanelHolder) SelectPrev() {
 	if N != 0 {
 		ind = ind - 1
 		if ind < 0 {
+			if p.switchMode == gxui.Linear {
+				return
+			}
 			ind = N - 1
 		}
 		p.Select(ind)
@@ -297,6 +305,14 @@ func (p *PanelHolder) SetMaxLabelLength(length int) {
 	for _, e := range p.entries {
 		e.Tab.SetMaxLabelLength(length)
 	}
+}
+
+func (p *PanelHolder) SwitchMode() gxui.SwitchMode {
+	return p.switchMode
+}
+
+func (p *PanelHolder) SetSwitchMode(mode gxui.SwitchMode) {
+	p.switchMode = mode
 }
 
 func (p *PanelHolder) update() {

--- a/mixins/panel_holder.go
+++ b/mixins/panel_holder.go
@@ -114,14 +114,25 @@ func (p *PanelHolder) Init(outer PanelHolderOuter, theme gxui.Theme) {
 
 	p.left = p.outer.CreatePanelTab()
 	p.left.SetVisible(p.begin != 0)
-	p.left.SetText("<-")
+
+	font := p.theme.DefaultFont()
+
+	if font.Index('◄') == 0 {
+		p.left.SetText("<-")
+	} else {
+		p.left.SetText("◄")
+	}
 	p.left.OnClick(func(ev gxui.MouseEvent) {
 		p.SelectPrev()
 	})
 	p.tabLayout.AddChild(p.left)
 
 	p.right = p.outer.CreatePanelTab()
-	p.right.SetText("->")
+	if font.Index('►') == 0 {
+		p.right.SetText("->")
+	} else {
+		p.right.SetText("►")
+	}
 	p.right.OnClick(func(ev gxui.MouseEvent) {
 		p.SelectNext()
 	})

--- a/mixins/panel_holder.go
+++ b/mixins/panel_holder.go
@@ -52,7 +52,8 @@ type PanelHolder struct {
 	begin int
 	end   int
 
-	switchMode gxui.SwitchMode
+	switchMode       gxui.SwitchMode
+	switchButtonMode gxui.SwitchButtonMode
 }
 
 func insertIndex(holder gxui.PanelHolder, at math.Point) int {
@@ -111,6 +112,7 @@ func (p *PanelHolder) Init(outer PanelHolderOuter, theme gxui.Theme) {
 	p.tabLayout.SetDirection(gxui.LeftToRight)
 
 	p.left = p.outer.CreatePanelTab()
+	p.left.SetVisible(p.begin != 0)
 	p.left.SetText("<-")
 	p.left.OnClick(func(ev gxui.MouseEvent) {
 		p.SelectPrev()
@@ -122,11 +124,14 @@ func (p *PanelHolder) Init(outer PanelHolderOuter, theme gxui.Theme) {
 	p.right.OnClick(func(ev gxui.MouseEvent) {
 		p.SelectNext()
 	})
+	p.right.SetVisible(p.end < len(p.entries))
 	p.tabLayout.AddChild(p.right)
 
 	p.Container.AddChild(p.tabLayout)
 	p.SetMargin(math.Spacing{L: 1, T: 2, R: 1, B: 1})
 	p.SetMouseEventTarget(true) // For drag-drop targets
+
+	p.switchButtonMode = gxui.Smart
 
 	// Interface compliance test
 	_ = gxui.PanelHolder(p)
@@ -315,6 +320,14 @@ func (p *PanelHolder) SetSwitchMode(mode gxui.SwitchMode) {
 	p.switchMode = mode
 }
 
+func (p *PanelHolder) SwitchButtonMode() gxui.SwitchButtonMode {
+	return p.switchButtonMode
+}
+
+func (p *PanelHolder) SetSwitchButtonMode(mode gxui.SwitchButtonMode) {
+	p.switchButtonMode = mode
+}
+
 func (p *PanelHolder) update() {
 	for len(p.tabLayout.Children()) != 2 {
 		p.tabLayout.RemoveChildAt(1)
@@ -332,6 +345,11 @@ func (p *PanelHolder) update() {
 			p.end--
 			break
 		}
+	}
+
+	if p.switchButtonMode == gxui.Smart {
+		p.left.SetVisible(p.begin != 0)
+		p.right.SetVisible(p.end < len(p.entries))
 	}
 }
 

--- a/mixins/panel_holder.go
+++ b/mixins/panel_holder.go
@@ -329,6 +329,14 @@ func (p *PanelHolder) SetSwitchButtonMode(mode gxui.SwitchButtonMode) {
 	p.switchButtonMode = mode
 }
 
+func (p *PanelHolder) SetRightSwitchButtonText(text string) {
+	p.right.SetText(text)
+}
+
+func (p *PanelHolder) SetLeftSwitchButtonText(text string) {
+	p.left.SetText(text)
+}
+
 func (p *PanelHolder) update() {
 	for len(p.tabLayout.Children()) != 2 {
 		p.tabLayout.RemoveChildAt(1)

--- a/mixins/panel_holder.go
+++ b/mixins/panel_holder.go
@@ -16,6 +16,9 @@ type PanelTab interface {
 	gxui.Control
 	SetText(string)
 	SetActive(bool)
+	SetMaxLabelLength(int)
+	LabelLength() int
+	HasFixedLength() bool
 }
 
 type PanelTabCreater interface {
@@ -288,6 +291,12 @@ func (p *PanelHolder) Begin() int {
 
 func (p *PanelHolder) End() int {
 	return p.end
+}
+
+func (p *PanelHolder) SetMaxLabelLength(length int) {
+	for _, e := range p.entries {
+		e.Tab.SetMaxLabelLength(length)
+	}
 }
 
 func (p *PanelHolder) update() {

--- a/panel_holder.go
+++ b/panel_holder.go
@@ -18,4 +18,5 @@ type PanelHolder interface {
 	Tab(int) Control
 	Begin() int
 	End() int
+	SetMaxLabelLength(int)
 }

--- a/panel_holder.go
+++ b/panel_holder.go
@@ -33,4 +33,6 @@ type PanelHolder interface {
 	SetSwitchMode(SwitchMode)
 	SwitchButtonMode() SwitchButtonMode
 	SetSwitchButtonMode(SwitchButtonMode)
+	SetRightSwitchButtonText(text string)
+	SetLeftSwitchButtonText(text string)
 }

--- a/panel_holder.go
+++ b/panel_holder.go
@@ -5,10 +5,13 @@
 package gxui
 
 type SwitchMode int
+type SwitchButtonMode int
 
 const (
 	Linear SwitchMode = iota
 	Circular
+	Smart SwitchButtonMode = iota
+	Constant
 )
 
 type PanelHolder interface {
@@ -28,4 +31,6 @@ type PanelHolder interface {
 	SetMaxLabelLength(int)
 	SwitchMode() SwitchMode
 	SetSwitchMode(SwitchMode)
+	SwitchButtonMode() SwitchButtonMode
+	SetSwitchButtonMode(SwitchButtonMode)
 }

--- a/panel_holder.go
+++ b/panel_holder.go
@@ -10,8 +10,12 @@ type PanelHolder interface {
 	AddPanelAt(panel Control, name string, index int)
 	RemovePanel(panel Control)
 	Select(int)
+	SelectNext()
+	SelectPrev()
 	PanelCount() int
 	PanelIndex(Control) int
 	Panel(int) Control
 	Tab(int) Control
+	Begin() int
+	End() int
 }

--- a/panel_holder.go
+++ b/panel_holder.go
@@ -4,6 +4,13 @@
 
 package gxui
 
+type SwitchMode int
+
+const (
+	Linear SwitchMode = iota
+	Circular
+)
+
 type PanelHolder interface {
 	Control
 	AddPanel(panel Control, name string)
@@ -19,4 +26,6 @@ type PanelHolder interface {
 	Begin() int
 	End() int
 	SetMaxLabelLength(int)
+	SwitchMode() SwitchMode
+	SetSwitchMode(SwitchMode)
 }

--- a/themes/basic/panel_tab.go
+++ b/themes/basic/panel_tab.go
@@ -12,8 +12,10 @@ import (
 
 type PanelTab struct {
 	mixins.Button
-	theme  *Theme
-	active bool
+	theme          *Theme
+	active         bool
+	maxLabelLength int
+	text           string
 }
 
 func CreatePanelTab(theme *Theme) mixins.PanelTab {
@@ -27,12 +29,41 @@ func CreatePanelTab(theme *Theme) mixins.PanelTab {
 	t.OnMouseUp(func(gxui.MouseEvent) { t.Redraw() })
 	t.OnGainedFocus(t.Redraw)
 	t.OnLostFocus(t.Redraw)
+	t.maxLabelLength = -1
 	return t
 }
 
 func (t *PanelTab) SetActive(active bool) {
 	t.active = active
 	t.Redraw()
+}
+
+func (t *PanelTab) SetMaxLabelLength(length int) {
+	if t.maxLabelLength != length {
+		t.maxLabelLength = length
+	}
+	t.update()
+}
+
+func (t *PanelTab) LabelLength() int {
+	return t.maxLabelLength
+}
+
+func (t *PanelTab) HasFixedLength() bool {
+	return t.maxLabelLength != -1
+}
+
+func (t *PanelTab) SetText(str string) {
+	t.text = str
+	t.update()
+}
+
+func (t *PanelTab) update() {
+	if t.maxLabelLength != -1 && t.maxLabelLength < len(t.text) {
+		t.Button.SetText(t.text[:t.maxLabelLength] + "...")
+	} else {
+		t.Button.SetText(t.text)
+	}
 }
 
 func (t *PanelTab) Paint(c gxui.Canvas) {


### PR DESCRIPTION
My proposal for solving [Show "real" path to file when switching tabs(Label on panel doesn't switch)](https://github.com/nelsam/vidar/issues/142) issue. 

Current ToDo list: 

- [x] Add buttons to panel holder for tab switch;
- [x] Update labels after resize;
- [x] Better marks for buttons; 
- [x] Optional setting of maximum length of string for labels;
- [x] Mode for hiding switch buttons if they don't need; 
- [x] Diferent mods for switching tabs (circular and usual) 
