### PR TITLE
mixins.ScrollLayout: defer the SetScrollOffset call in LayoutChildren

### DIFF
--- a/mixins/scroll_layout.go
+++ b/mixins/scroll_layout.go
@@ -81,7 +81,7 @@ func (l *ScrollLayout) LayoutChildren() {
 		l.scrollBarY.Control.(gxui.ScrollBar).SetScrollLimit(cs.H)
 	}
 
-	l.SetScrollOffset(l.scrollOffset)
+	l.theme.Driver().Call(func() { l.SetScrollOffset(l.scrollOffset) })
 }
 
 func (l *ScrollLayout) DesiredSize(min, max math.Size) math.Size {


### PR DESCRIPTION
LayoutChildren was calling SetScrollOffset, which was calling Relayout, which was panicking because it was in LayoutChildren.  This adds the call to SetScrollOffset to the UI goroutine for later execution to avoid that panic.

Resolves nelsam/vidar#152.