### PR TITLE
mixins.CodeEditor: only update horizontal scrolling stuff if the offset has changed

### DIFF
--- a/mixins/code_editor.go
+++ b/mixins/code_editor.go
@@ -254,10 +254,10 @@ func (e *CodeEditor) CreateLine(theme gxui.Theme, index int) (TextBoxLine, gxui.
 }
 
 func (e *CodeEditor) SetHorizOffset(offset int) {
-	e.updateHorizScrollLimit()
-	e.updateChildOffsets(e, offset)
-	e.horizScroll.SetScrollPosition(offset, offset+e.Size().W)
 	if e.horizOffset != offset {
+		e.updateHorizScrollLimit()
+		e.updateChildOffsets(e, offset)
+		e.horizScroll.SetScrollPosition(offset, offset+e.Size().W)
 		e.horizOffset = offset
 		e.LayoutChildren()
 	}


### PR DESCRIPTION
This solves a pretty common lockup of the UI if you try to select text.  The editor would get stuck in a near-infinite loop trying to update the horizontal offset.  Oddly enough, it's not easily reproduceable in files that actually have a horizontal scroll bar (due to having long lines).