### PR TITLE
Set hscrolloffset = 0 if entire content is visible

### DIFF
--- a/mixins/textbox.go
+++ b/mixins/textbox.go
@@ -163,6 +163,9 @@ func (t *TextBox) LayoutChildren() {
 		maxLineWidth := t.outer.MaxLineWidth()
 		entireContentVisible := size.W > maxLineWidth
 		t.horizScroll.SetVisible(!entireContentVisible)
+		if entireContentVisible && t.horizOffset != 0 {
+			t.SetHorizOffset(0)
+		}
 	}
 }
 


### PR DESCRIPTION
In current state it possible not have scrollbar after resizing but have view that has starts with shifted position. 