### PR TITLE
Set theme before Init PanelHolder

### DIFF
--- a/themes/basic/panel_holder.go
+++ b/themes/basic/panel_holder.go
@@ -17,8 +17,8 @@ type PanelHolder struct {
 
 func CreatePanelHolder(theme *Theme) gxui.PanelHolder {
 	p := &PanelHolder{}
-	p.PanelHolder.Init(p, theme)
 	p.theme = theme
+	p.PanelHolder.Init(p, theme)
 	p.SetMargin(math.Spacing{L: 0, T: 2, R: 0, B: 0})
 	return p
 }


### PR DESCRIPTION
If build and run panel sample then get such error: 

> panic: runtime error: invalid memory address or nil pointer dereference
> [signal 0xc0000005 code=0x0 addr=0x8 pc=0x5e5995]
> 
> goroutine 19 [running]:
> github.com/nelsam/gxui/themes/basic.(*Theme).Driver(0x0, 0x78e500, 0x3355160)
>         T:/libraries/Gopath/src/github.com/nelsam/gxui/themes/basic/theme.go:45 +0x5

That is happening because theme is used inside Init method when [creating PanelTab](https://github.com/nelsam/gxui/blob/master/mixins/panel_holder.go#L115). 
So setting theme first is fixed the issue. 
